### PR TITLE
Fix auth comparison and add coverage with c8

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -2,5 +2,5 @@ esm: false
 ts: false
 jsx: false
 flow: false
-coverage: true
+coverage: false
 jobs: 1

--- a/app.js
+++ b/app.js
@@ -3,7 +3,10 @@ import jwt from 'fastify-jwt'
 
 export default async function (app, opts) {
   app.register(jwt, {
-    secret: 'CHANGEME'
+    secret: 'CHANGEME',
+    sign: {
+      expiresIn: 3600
+    }
   })
 
   app.decorate('authenticate', async function (request, reply) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "standard && tap -J `find ./test -name *.test.js`"
+    "test": "standard && tap",
+    "coverage": "c8 npm test"
   },
   "repository": {
     "type": "git",
@@ -29,6 +30,7 @@
     "pino-pretty": "^4.3.0"
   },
   "devDependencies": {
+    "c8": "^7.3.5",
     "standard": "^16.0.3",
     "tap": "^14.11.0"
   }

--- a/routes/login.js
+++ b/routes/login.js
@@ -11,7 +11,7 @@ export default async function (app, opts) {
   }, async (req, res) => {
     const { username, password } = req.body
 
-    if (username !== 'matteo' && password !== 'collina') {
+    if (!(username === 'matteo' && password === 'collina')) {
       throw new errors.Unauthorized()
     }
 

--- a/test/routes/login.test.js
+++ b/test/routes/login.test.js
@@ -1,0 +1,43 @@
+import t from 'tap'
+import fastify from 'fastify'
+import fp from 'fastify-plugin'
+import app from '../../app.js'
+
+const { test } = t
+
+test('login to obtain token for authentication', async (t) => {
+  const server = fastify()
+
+  // so we can access decorators
+  server.register(fp(app))
+
+  const wrongPassword = await server.inject({
+    url: '/login',
+    method: 'POST',
+    body: {
+      username: 'matteo',
+      password: 'santos'
+    }
+  })
+  t.is(wrongPassword.statusCode, 401)
+
+  const { token } = (await server.inject({
+    url: '/login',
+    method: 'POST',
+    body: {
+      username: 'matteo',
+      password: 'collina'
+    }
+  })).json()
+
+  const res = await server.inject({
+    url: '/protected/something',
+    headers: {
+      authorization: `Bearer ${token}`
+    }
+  })
+
+  t.deepEqual(res.json(), { hello: 'world' })
+
+  await server.close()
+})

--- a/test/routes/protected/index.test.js
+++ b/test/routes/protected/index.test.js
@@ -1,0 +1,18 @@
+import t from 'tap'
+import fastify from 'fastify'
+import fp from 'fastify-plugin'
+import app from '../../../app.js'
+
+const test = t.test
+
+test('no token provided for authentication', async (t) => {
+  const server = fastify()
+
+  // so we can access decorators
+  server.register(fp(app))
+
+  const res = await server.inject('/protected/something')
+  t.is(res.statusCode, 401)
+
+  await server.close()
+})


### PR DESCRIPTION
Ciao Matteo,
as we are using ESM here on this examples, it was necessary to use c8 instead of nyc (used by tap). Fixed a small bug on auth check.
BTW, you prefer a folder "test" with all tests like this or having a xxx.test.js file on the same dir of the xxx.js file?